### PR TITLE
[U.O.F-Mobile] Request, Response 코드 적용 및 TextInputLayout 오류 수정

### DIFF
--- a/app/src/main/java/com/uof/uof_mobile/Constants.java
+++ b/app/src/main/java/com/uof/uof_mobile/Constants.java
@@ -8,7 +8,7 @@ public class Constants {
 
         public class Request {
             public final static String REGISTER_CUSTOMER = "0001";
-            public final static String REGISTER_OWNER = "0002";
+            public final static String REGISTER_UOFPARTNER = "0002";
             public final static String LOGIN = "0003";
             public final static String CHANGE_PW = "0004";
             public final static String CHANGE_PHONE_NUMBER = "0005";

--- a/app/src/main/java/com/uof/uof_mobile/LoginActivity.java
+++ b/app/src/main/java/com/uof/uof_mobile/LoginActivity.java
@@ -112,12 +112,12 @@ public class LoginActivity extends AppCompatActivity {
                     startActivity(intent);
                 } else if (responseCode.equals(Constants.Network.Response.LOGIN_FAILED_ID_NOT_EXIST)) {
                     // 로그인 실패 - 아이디 없음
-                    tilLoginId.setErrorEnabled(true);
                     tilLoginId.setError("아이디가 존재하지 않습니다");
+                    tilLoginId.setErrorEnabled(true);
                 } else if (responseCode.equals(Constants.Network.Response.LOGIN_FAILED_PW_NOT_CORRECT)) {
                     // 로그인 실패 - 비밀번호 틀림
-                    tilLoginPw.setErrorEnabled(true);
                     tilLoginPw.setError("비밀번호가 일치하지 않습니다");
+                    tilLoginPw.setErrorEnabled(true);
                 } else {
                     // 로그인 실패 - 기타 오류
                     Toast.makeText(LoginActivity.this, "로그인 실패: " + recvData.getString("message"), Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/com/uof/uof_mobile/LoginActivity.java
+++ b/app/src/main/java/com/uof/uof_mobile/LoginActivity.java
@@ -18,7 +18,6 @@ import com.google.android.material.textfield.TextInputLayout;
 import org.json.JSONObject;
 
 public class LoginActivity extends AppCompatActivity {
-    private ImageView ivLoginRecognizeQR;
     private TextInputLayout tilLoginId;
     private TextInputLayout tilLoginPw;
     private Button btnLoginLogin;
@@ -34,7 +33,6 @@ public class LoginActivity extends AppCompatActivity {
     }
 
     private void init() {
-        ivLoginRecognizeQR = findViewById(R.id.iv_login_recognizeqr);
         tilLoginId = findViewById(R.id.til_login_id);
         tilLoginPw = findViewById(R.id.til_login_pw);
         btnLoginLogin = findViewById(R.id.btn_login_login);
@@ -47,11 +45,6 @@ public class LoginActivity extends AppCompatActivity {
         // 기본 UI 상태 설정
         btnLoginLogin.setEnabled(false);
         llLoginLoginLayout.setVisibility(View.VISIBLE);
-
-        // QR 코드 인식하기 ImageView가 눌렸을 경우
-        ivLoginRecognizeQR.setOnClickListener(view -> {
-            startActivity(new Intent(LoginActivity.this, QRRecognitionActivity.class));
-        });
 
         // 로그인 - 아이디 입력란이 수정되었을 경우
         tilLoginId.getEditText().addTextChangedListener(new TextWatcher() {
@@ -100,30 +93,31 @@ public class LoginActivity extends AppCompatActivity {
             // 로그인 창일 경우
             try {
                 JSONObject sendData = new JSONObject();
-                sendData.put("request_code", "1002");
+                sendData.put("request_code", Constants.Network.Request.LOGIN);
 
                 JSONObject message = new JSONObject();
                 message.accumulate("id", tilLoginId.getEditText().getText().toString());
                 message.accumulate("pw", tilLoginPw.getEditText().getText().toString());
+                message.accumulate("type", "customer");
 
                 sendData.accumulate("message", message);
 
                 JSONObject recvData = new JSONObject(new HttpManager().execute(new String[]{"http://211.217.202.157:8080/post", sendData.toString()}).get());
 
-                String requestCode = recvData.getString("request_code");
+                String responseCode = recvData.getString("response_code");
 
-                if (requestCode.equals("0003")) {
+                if (responseCode.equals(Constants.Network.Response.LOGIN_SUCCESS)) {
                     // 로그인 성공 - LobbyActivity로 이동
                     Intent intent = new Intent(LoginActivity.this, LobbyActivity.class);
                     startActivity(intent);
-                } else if (requestCode.equals("0004")) {
+                } else if (responseCode.equals(Constants.Network.Response.LOGIN_FAILED_ID_NOT_EXIST)) {
                     // 로그인 실패 - 아이디 없음
                     tilLoginId.setErrorEnabled(true);
                     tilLoginId.setError("아이디가 존재하지 않습니다");
-                } else if (requestCode.equals("0005")) {
+                } else if (responseCode.equals(Constants.Network.Response.LOGIN_FAILED_PW_NOT_CORRECT)) {
                     // 로그인 실패 - 비밀번호 틀림
-                    tilLoginId.setErrorEnabled(true);
-                    tilLoginId.setError("비밀번호가 일치하지 않습니다");
+                    tilLoginPw.setErrorEnabled(true);
+                    tilLoginPw.setError("비밀번호가 일치하지 않습니다");
                 } else {
                     // 로그인 실패 - 기타 오류
                     Toast.makeText(LoginActivity.this, "로그인 실패: " + recvData.getString("message"), Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/com/uof/uof_mobile/RegisterActivity.java
+++ b/app/src/main/java/com/uof/uof_mobile/RegisterActivity.java
@@ -426,7 +426,7 @@ public class RegisterActivity extends AppCompatActivity {
 
                 if (result == Constants.Pattern.LENGTH_SHORT || result == Constants.Pattern.NOT_ALLOWED_CHARACTER) {
                     tilRegisterLicenseNumber.setErrorEnabled(true);
-                    tilRegisterLicenseNumber.setError("사업자번호는 9자리의 숫자입니다");
+                    tilRegisterLicenseNumber.setError("사업자번호는 10자리 숫자입니다");
                 } else {
                     tilRegisterLicenseNumber.setErrorEnabled(false);
                     tilRegisterLicenseNumber.setError(null);
@@ -478,7 +478,7 @@ public class RegisterActivity extends AppCompatActivity {
             // 회원가입 창일 경우
             try {
                 JSONObject sendData = new JSONObject();
-                sendData.put("request_code", "0001");
+                sendData.put("request_code", Constants.Network.Request.REGISTER_CUSTOMER);
 
                 JSONObject message = new JSONObject();
                 message.put("id", tilRegisterCustomerId.getEditText().getText().toString());
@@ -490,13 +490,13 @@ public class RegisterActivity extends AppCompatActivity {
 
                 JSONObject recvData = new JSONObject(new HttpManager().execute(new String[]{"http://211.217.202.157:8080/post", sendData.toString()}).get());
 
-                String requestCode = recvData.getString("request_code");
+                String requestCode = recvData.getString("response_code");
 
-                if (requestCode.equals("0001")) {
+                if (requestCode.equals(Constants.Network.Response.REGISTER_SUCCESS)) {
                     // 회원가입 성공 - 로그인창 표시
                     Toast.makeText(RegisterActivity.this, "가입되었습니다. 해당 계정으로 로그인해주세요.", Toast.LENGTH_SHORT).show();
                     finish();
-                } else if (requestCode.equals("0002")) {
+                } else if (requestCode.equals(Constants.Network.Response.REGISTER_FAILED_ID_DUPLICATE)) {
                     // 회원가입 실패 - 아이디 중복
                     tilRegisterCustomerId.setErrorEnabled(true);
                     tilRegisterCustomerId.setError("해당 아이디는 이미 사용중입니다");
@@ -517,7 +517,7 @@ public class RegisterActivity extends AppCompatActivity {
             // 회원가입 창일 경우
             try {
                 JSONObject sendData = new JSONObject();
-                sendData.put("request_code", "0002");
+                sendData.put("request_code", Constants.Network.Request.REGISTER_UOFPARTNER);
 
                 JSONObject message = new JSONObject();
                 message.put("id", tilRegisterUofPartnerId.getEditText().getText().toString());
@@ -537,13 +537,13 @@ public class RegisterActivity extends AppCompatActivity {
 
                 JSONObject recvData = new JSONObject(new HttpManager().execute(new String[]{"http://211.217.202.157:8080/post", sendData.toString()}).get());
 
-                String requestCode = recvData.getString("request_code");
+                String requestCode = recvData.getString("response_code");
 
-                if (requestCode.equals("0001")) {
+                if (requestCode.equals(Constants.Network.Response.REGISTER_SUCCESS)) {
                     // 회원가입 성공 - 로그인창 표시
                     Toast.makeText(RegisterActivity.this, "가입되었습니다. 해당 계정으로 로그인해주세요.", Toast.LENGTH_SHORT).show();
                     finish();
-                } else if (requestCode.equals("0002")) {
+                } else if (requestCode.equals(Constants.Network.Response.REGISTER_FAILED_ID_DUPLICATE)) {
                     // 회원가입 실패 - 아이디 중복
                     tilRegisterUofPartnerId.setErrorEnabled(true);
                     tilRegisterUofPartnerId.setError("해당 아이디는 이미 사용중입니다");
@@ -639,7 +639,7 @@ public class RegisterActivity extends AppCompatActivity {
 
     // 회원가입 - 사업자번호 패턴 확인
     private int checkRegisterLicenseNumber(String licenseNumber) {
-        if (licenseNumber.length() < 9) {
+        if (licenseNumber.length() < 10) {
             return Constants.Pattern.LENGTH_SHORT;
         } else if (!java.util.regex.Pattern.matches("^[0-9]+$", licenseNumber)) {
             return Constants.Pattern.NOT_ALLOWED_CHARACTER;

--- a/app/src/main/java/com/uof/uof_mobile/RegisterActivity.java
+++ b/app/src/main/java/com/uof/uof_mobile/RegisterActivity.java
@@ -122,14 +122,14 @@ public class RegisterActivity extends AppCompatActivity {
                 int result = checkRegisterId(editable.toString());
 
                 if (result == Constants.Pattern.LENGTH_SHORT) {
-                    tilRegisterCustomerId.setErrorEnabled(true);
                     tilRegisterCustomerId.setError("아이디는 8자리 이상이어야 합니다");
-                } else if (result == Constants.Pattern.NOT_ALLOWED_CHARACTER) {
                     tilRegisterCustomerId.setErrorEnabled(true);
+                } else if (result == Constants.Pattern.NOT_ALLOWED_CHARACTER) {
                     tilRegisterCustomerId.setError("알파벳, 숫자, !@#*만 사용할 수 있습니다");
+                    tilRegisterCustomerId.setErrorEnabled(true);
                 } else {
-                    tilRegisterCustomerId.setErrorEnabled(false);
                     tilRegisterCustomerId.setError(null);
+                    tilRegisterCustomerId.setErrorEnabled(false);
                 }
 
                 btnRegisterCustomerRegister.setEnabled(checkCustomerRegister());
@@ -151,22 +151,22 @@ public class RegisterActivity extends AppCompatActivity {
                 int result = checkRegisterPw(editable.toString());
 
                 if (result == Constants.Pattern.LENGTH_SHORT) {
-                    tilRegisterCustomerPw.setErrorEnabled(true);
                     tilRegisterCustomerPw.setError("비밀번호는 8자리 이상이어야 합니다");
-                } else if (result == Constants.Pattern.NOT_ALLOWED_CHARACTER) {
                     tilRegisterCustomerPw.setErrorEnabled(true);
+                } else if (result == Constants.Pattern.NOT_ALLOWED_CHARACTER) {
                     tilRegisterCustomerPw.setError("알파벳, 숫자, !@#*만 사용할 수 있습니다");
+                    tilRegisterCustomerPw.setErrorEnabled(true);
                 } else {
-                    tilRegisterCustomerPw.setErrorEnabled(false);
                     tilRegisterCustomerPw.setError(null);
+                    tilRegisterCustomerPw.setErrorEnabled(false);
                 }
 
                 if (!editable.toString().equals(tilRegisterCustomerPwChk.getEditText().getText().toString())) {
-                    tilRegisterCustomerPw.setErrorEnabled(true);
                     tilRegisterCustomerPwChk.setError("비밀번호가 일치하지 않습니다");
+                    tilRegisterUofPartnerPwChk.setErrorEnabled(true);
                 } else {
-                    tilRegisterCustomerPw.setErrorEnabled(false);
                     tilRegisterCustomerPwChk.setError(null);
+                    tilRegisterUofPartnerPwChk.setErrorEnabled(false);
                 }
 
                 btnRegisterCustomerRegister.setEnabled(checkCustomerRegister());
@@ -186,12 +186,12 @@ public class RegisterActivity extends AppCompatActivity {
             @Override
             public void afterTextChanged(Editable editable) {
                 if (!editable.toString().equals(tilRegisterCustomerPw.getEditText().getText().toString())) {
-                    tilRegisterCustomerPwChk.setErrorEnabled(true);
                     tilRegisterCustomerPwChk.setError("비밀번호가 일치하지 않습니다");
+                    tilRegisterCustomerPwChk.setErrorEnabled(true);
                     btnRegisterCustomerRegister.setEnabled(false);
                 } else {
-                    tilRegisterCustomerPwChk.setErrorEnabled(false);
                     tilRegisterCustomerPwChk.setError(null);
+                    tilRegisterCustomerPwChk.setErrorEnabled(false);
                     btnRegisterCustomerRegister.setEnabled(checkCustomerRegister());
                 }
             }
@@ -213,11 +213,11 @@ public class RegisterActivity extends AppCompatActivity {
                 int result = checkRegisterName(editable.toString());
 
                 if (result == Constants.Pattern.NOT_ALLOWED_CHARACTER) {
-                    tilRegisterCustomerName.setErrorEnabled(true);
                     tilRegisterCustomerName.setError("이름은 한글만 가능합니다");
+                    tilRegisterCustomerName.setErrorEnabled(true);
                 } else {
-                    tilRegisterCustomerName.setErrorEnabled(false);
                     tilRegisterCustomerName.setError(null);
+                    tilRegisterCustomerName.setErrorEnabled(false);
                 }
 
                 btnRegisterCustomerRegister.setEnabled(checkCustomerRegister());
@@ -239,11 +239,11 @@ public class RegisterActivity extends AppCompatActivity {
                 int result = checkRegisterPhoneNumber(editable.toString());
 
                 if (result == Constants.Pattern.LENGTH_SHORT || result == Constants.Pattern.NOT_ALLOWED_CHARACTER) {
-                    tilRegisterCustomerPhoneNumber.setErrorEnabled(true);
                     tilRegisterCustomerPhoneNumber.setError("전화번호 형식이 맞지 않습니다");
+                    tilRegisterCustomerPhoneNumber.setErrorEnabled(true);
                 } else {
-                    tilRegisterCustomerPhoneNumber.setErrorEnabled(false);
                     tilRegisterCustomerPhoneNumber.setError(null);
+                    tilRegisterCustomerPhoneNumber.setErrorEnabled(false);
                 }
 
                 btnRegisterCustomerRegister.setEnabled(checkCustomerRegister());
@@ -266,14 +266,14 @@ public class RegisterActivity extends AppCompatActivity {
                 int result = checkRegisterId(editable.toString());
 
                 if (result == Constants.Pattern.LENGTH_SHORT) {
-                    tilRegisterUofPartnerId.setErrorEnabled(true);
                     tilRegisterUofPartnerId.setError("아이디는 8자리 이상이어야 합니다");
-                } else if (result == Constants.Pattern.NOT_ALLOWED_CHARACTER) {
                     tilRegisterUofPartnerId.setErrorEnabled(true);
+                } else if (result == Constants.Pattern.NOT_ALLOWED_CHARACTER) {
                     tilRegisterUofPartnerId.setError("알파벳, 숫자, !@#*만 사용할 수 있습니다");
+                    tilRegisterUofPartnerId.setErrorEnabled(true);
                 } else {
-                    tilRegisterUofPartnerId.setErrorEnabled(false);
                     tilRegisterUofPartnerId.setError(null);
+                    tilRegisterUofPartnerId.setErrorEnabled(false);
                 }
 
                 btnRegisterUofPartnerRegister.setEnabled(checkUofPartnerRegister());
@@ -295,22 +295,22 @@ public class RegisterActivity extends AppCompatActivity {
                 int result = checkRegisterPw(editable.toString());
 
                 if (result == Constants.Pattern.LENGTH_SHORT) {
-                    tilRegisterUofPartnerPw.setErrorEnabled(true);
                     tilRegisterUofPartnerPw.setError("비밀번호는 8자리 이상이어야 합니다");
-                } else if (result == Constants.Pattern.NOT_ALLOWED_CHARACTER) {
                     tilRegisterUofPartnerPw.setErrorEnabled(true);
+                } else if (result == Constants.Pattern.NOT_ALLOWED_CHARACTER) {
                     tilRegisterUofPartnerPw.setError("알파벳, 숫자, !@#*만 사용할 수 있습니다");
+                    tilRegisterUofPartnerPw.setErrorEnabled(true);
                 } else {
-                    tilRegisterUofPartnerPw.setErrorEnabled(false);
                     tilRegisterUofPartnerPw.setError(null);
+                    tilRegisterUofPartnerPw.setErrorEnabled(false);
                 }
 
                 if (!editable.toString().equals(tilRegisterUofPartnerPwChk.getEditText().getText().toString())) {
-                    tilRegisterUofPartnerPw.setErrorEnabled(true);
                     tilRegisterUofPartnerPwChk.setError("비밀번호가 일치하지 않습니다");
+                    tilRegisterUofPartnerPwChk.setErrorEnabled(true);
                 } else {
-                    tilRegisterUofPartnerPw.setErrorEnabled(false);
                     tilRegisterUofPartnerPwChk.setError(null);
+                    tilRegisterUofPartnerPwChk.setErrorEnabled(false);
                 }
 
                 btnRegisterUofPartnerRegister.setEnabled(checkUofPartnerRegister());
@@ -330,12 +330,12 @@ public class RegisterActivity extends AppCompatActivity {
             @Override
             public void afterTextChanged(Editable editable) {
                 if (!editable.toString().equals(tilRegisterUofPartnerPw.getEditText().getText().toString())) {
-                    tilRegisterUofPartnerPwChk.setErrorEnabled(true);
                     tilRegisterUofPartnerPwChk.setError("비밀번호가 일치하지 않습니다");
+                    tilRegisterUofPartnerPwChk.setErrorEnabled(true);
                     btnRegisterUofPartnerRegister.setEnabled(false);
                 } else {
-                    tilRegisterUofPartnerPwChk.setErrorEnabled(false);
                     tilRegisterUofPartnerPwChk.setError(null);
+                    tilRegisterUofPartnerPwChk.setErrorEnabled(false);
                     btnRegisterUofPartnerRegister.setEnabled(checkUofPartnerRegister());
                 }
             }
@@ -357,11 +357,11 @@ public class RegisterActivity extends AppCompatActivity {
                 int result = checkRegisterName(editable.toString());
 
                 if (result == Constants.Pattern.NOT_ALLOWED_CHARACTER) {
-                    tilRegisterUofPartnerName.setErrorEnabled(true);
                     tilRegisterUofPartnerName.setError("이름은 한글만 가능합니다");
+                    tilRegisterUofPartnerName.setErrorEnabled(true);
                 } else {
-                    tilRegisterUofPartnerName.setErrorEnabled(false);
                     tilRegisterUofPartnerName.setError(null);
+                    tilRegisterUofPartnerName.setErrorEnabled(false);
                 }
 
                 btnRegisterUofPartnerRegister.setEnabled(checkUofPartnerRegister());
@@ -383,11 +383,11 @@ public class RegisterActivity extends AppCompatActivity {
                 int result = checkRegisterPhoneNumber(editable.toString());
 
                 if (result == Constants.Pattern.LENGTH_SHORT || result == Constants.Pattern.NOT_ALLOWED_CHARACTER) {
-                    tilRegisterUofPartnerPhoneNumber.setErrorEnabled(true);
                     tilRegisterUofPartnerPhoneNumber.setError("전화번호 형식이 맞지 않습니다");
+                    tilRegisterUofPartnerPhoneNumber.setErrorEnabled(true);
                 } else {
-                    tilRegisterUofPartnerPhoneNumber.setErrorEnabled(false);
                     tilRegisterUofPartnerPhoneNumber.setError(null);
+                    tilRegisterUofPartnerPhoneNumber.setErrorEnabled(false);
                 }
 
                 btnRegisterUofPartnerRegister.setEnabled(checkUofPartnerRegister());
@@ -425,11 +425,11 @@ public class RegisterActivity extends AppCompatActivity {
                 int result = checkRegisterLicenseNumber(editable.toString());
 
                 if (result == Constants.Pattern.LENGTH_SHORT || result == Constants.Pattern.NOT_ALLOWED_CHARACTER) {
-                    tilRegisterLicenseNumber.setErrorEnabled(true);
                     tilRegisterLicenseNumber.setError("사업자번호는 10자리 숫자입니다");
+                    tilRegisterLicenseNumber.setErrorEnabled(true);
                 } else {
-                    tilRegisterLicenseNumber.setErrorEnabled(false);
                     tilRegisterLicenseNumber.setError(null);
+                    tilRegisterLicenseNumber.setErrorEnabled(false);
                 }
 
                 btnRegisterUofPartnerRegister.setEnabled(checkUofPartnerRegister());
@@ -498,8 +498,8 @@ public class RegisterActivity extends AppCompatActivity {
                     finish();
                 } else if (requestCode.equals(Constants.Network.Response.REGISTER_FAILED_ID_DUPLICATE)) {
                     // 회원가입 실패 - 아이디 중복
-                    tilRegisterCustomerId.setErrorEnabled(true);
                     tilRegisterCustomerId.setError("해당 아이디는 이미 사용중입니다");
+                    tilRegisterCustomerId.setErrorEnabled(true);
                     tilRegisterCustomerId.getEditText().setFocusableInTouchMode(true);
                     tilRegisterCustomerId.getEditText().requestFocus();
                 } else {
@@ -545,8 +545,8 @@ public class RegisterActivity extends AppCompatActivity {
                     finish();
                 } else if (requestCode.equals(Constants.Network.Response.REGISTER_FAILED_ID_DUPLICATE)) {
                     // 회원가입 실패 - 아이디 중복
-                    tilRegisterUofPartnerId.setErrorEnabled(true);
                     tilRegisterUofPartnerId.setError("해당 아이디는 이미 사용중입니다");
+                    tilRegisterUofPartnerId.setErrorEnabled(true);
                     tilRegisterUofPartnerId.getEditText().setFocusableInTouchMode(true);
                     tilRegisterUofPartnerId.getEditText().requestFocus();
                 } else {

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -17,24 +17,8 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_weight="5"
-            android:orientation="vertical">
-
-            <ImageView
-                android:id="@+id/iv_login_recognizeqr"
-                android:layout_width="150dp"
-                android:layout_height="150dp"
-                android:layout_gravity="center"
-                android:src="@drawable/qrcode" />
-
-            <TextView
-                android:id="@+id/tv_login_notify"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:layout_marginTop="16dp"
-                android:text="비 회원은 위 버튼을 눌러 QR코드를 인식해주세요!"
-                android:textColor="#ff0000"
-                app:layout_constraintTop_toTopOf="parent" />
+            android:orientation="vertical"
+            android:gravity="center">
 
             <TextView
                 android:id="@+id/tv_login_name1"
@@ -42,7 +26,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:layout_marginTop="16dp"
-                android:text="나만의 키오스크\nUOF"
+                android:text="나만의 키오스크\nU.O.F"
                 android:textAlignment="center"
                 android:textSize="32sp"
                 android:textStyle="bold"

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -89,7 +89,6 @@
                 </com.google.android.material.textfield.TextInputLayout>
 
                 <androidx.appcompat.widget.AppCompatTextView
-                    android:id="@+id/tv_register_pwchk"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="비밀번호 확인"
@@ -304,7 +303,6 @@
                 </com.google.android.material.textfield.TextInputLayout>
 
                 <androidx.appcompat.widget.AppCompatTextView
-                    android:id="@+id/tv_register_companyinfo"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="20dp"
@@ -314,7 +312,6 @@
                     android:textStyle="bold" />
 
                 <androidx.appcompat.widget.AppCompatTextView
-                    android:id="@+id/tv_register_companyname"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="회사명"
@@ -350,7 +347,7 @@
                         style="@style/TextInputEditText_Register"
                         android:hint="사업자번호를 입력해주세요"
                         android:inputType="phone"
-                        android:maxLength="9" />
+                        android:maxLength="10" />
                 </com.google.android.material.textfield.TextInputLayout>
 
                 <androidx.appcompat.widget.AppCompatTextView


### PR DESCRIPTION
## 주요 변경사항
> ## TextInputLayout 오류 수정
> - TextInputLayout에서 오류 메세지가 지워지고 나서도 영역이 남아있는 오류 수정
> - setError() 함수를 setErrorEnable() 함수보다 먼저 실행
<br>

## 기타 변경사항
> ## 디자인
> 1. 불필요한 UI id 제거
> 2. 로그인 화면 QR이미지 및 설명란 제거
> <br>
>
> ## 기능
> 1. 기존에 String 형으로 상수로 구분하던 Request Code, Response Code를 Constants.Network에 있는 상수들로 대체
> 2. 로그인 시 비밀번호 불일치 오류 메세지가 ID 입력란에 표시되던 오류 수정
> 3. 응답 JSON에서 response_code를 추출해야 하는데 request_code를 추출하는 오류 수정